### PR TITLE
DRAFT: does not work

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -47225,6 +47225,9 @@ static int test_wolfSSL_d2i_and_i2d_PublicKey(void)
     /* Check that key can be successfully encoded. */
     AssertIntGE((derLen = wolfSSL_i2d_PublicKey(pkey, &der)), 0);
     /* Ensure that the encoded version matches the original. */
+    FILE * f = fopen("asdfasdf", "w");
+    fwrite(der, derLen, 1, f);
+    fclose(f);
     AssertIntEQ(derLen, sizeof_client_keypub_der_2048);
     AssertIntEQ(XMEMCMP(der, client_keypub_der_2048, derLen), 0);
 


### PR DESCRIPTION
Many things wrong with this.
- 512 should be max rsa public key size. 
- unit test fails. 
- dump of the rsa key looks weird. Random. 
- We should fix i2d_PUBKEY() as well. 

Need help with the RSA case.  Can't figure out what is wrong with it. 

```
/configure --enable-opensslextra --enable-debug
make all check
od -t x1 < ./certs/client-keyPub.der
od -t x1 < asdfasdf
```

